### PR TITLE
Removed green lightbox

### DIFF
--- a/bash/debian.inc.sh
+++ b/bash/debian.inc.sh
@@ -64,9 +64,11 @@ function debian_stop_cr {
 
 function debian_config_assistant {
 
-    logConsole "\033[44m\033[1;37m"
-    printTitle "Lauching CentralReport configuration wizard..."
-    logConsole "\033[0m"
+    logFile "Launching CentralReport configuration wizard..."
+
+    printLightBox blue " "
+    printLightBox blue " Launching CentralReport configuration wizard..."
+    printLightBox blue " "
 
     python ${CONFIG_ASSISTANT} < /dev/tty
 

--- a/bash/log.inc.sh
+++ b/bash/log.inc.sh
@@ -34,7 +34,7 @@ function printTitle() {
     logConsole "--------------------------------------------------------------------------------"
 }
 
-# Writes a light box on console. Available colors: blue, green and red.
+# Writes a light box on console. Available colors: blue and red.
 function printLightBox() {
 
     LIGHTBOX_COLOR="$1"
@@ -51,8 +51,6 @@ function printLightBox() {
         LIGHTBOX_TEXT="\033[0;44m\033[37m${LIGHTBOX_TEXT}\033[0m"
     elif [ ${LIGHTBOX_COLOR} == "red" ]; then
         LIGHTBOX_TEXT="\033[0;41m\033[37m${LIGHTBOX_TEXT}\033[0m"
-    elif [ ${LIGHTBOX_COLOR} == "green" ]; then
-        LIGHTBOX_TEXT="\033[0;42m\033[37m${LIGHTBOX_TEXT}\033[0m"
     fi
 
     logConsole "${LIGHTBOX_TEXT}"

--- a/bash/macos.inc.sh
+++ b/bash/macos.inc.sh
@@ -65,9 +65,11 @@ function macos_stop_cr {
 # --
 function macos_config_assistant {
 
-    logConsole "\033[1;32m"
-    logInfo "Launching CentralReport configuration wizard..."
-    logConsole "\033[0m"
+    logFile "Launching CentralReport configuration wizard..."
+
+    printLightBox blue " "
+    printLightBox blue " Launching CentralReport configuration wizard..."
+    printLightBox blue " "
 
     sudo python ${CONFIG_ASSISTANT} < /dev/tty
 

--- a/centralreport/config.py
+++ b/centralreport/config.py
@@ -115,12 +115,7 @@ if __name__ == '__main__':
             print '\n'
             print 'Restarting CentralReport...'
             daemon.start()
-
-        print '\n'
-        print '--------------------------------------------------------------------------------'
-        print '                          End of the config script                              '
-        print '--------------------------------------------------------------------------------'
-
+            
         sys.exit(0)
 
     elif 'update' == sys.argv[1]:

--- a/centralreport/config.py
+++ b/centralreport/config.py
@@ -115,7 +115,7 @@ if __name__ == '__main__':
             print '\n'
             print 'Restarting CentralReport...'
             daemon.start()
-            
+
         sys.exit(0)
 
     elif 'update' == sys.argv[1]:

--- a/install.sh
+++ b/install.sh
@@ -103,7 +103,7 @@ if [ "install" == ${ACTUAL_MODE} ]; then
             logFile "CentralReport is now installed! For more options, you can edit the config file at /etc/centralreport.cfg"
             logFile "More help at http://github.com/miniche/CentralReport. Have fun!"
 
-            # Adds a space before the lightbox to separate previous logs with the success message.
+            # Adding a space before the lightbox to separate previous logs with the success message.
             logConsole " "
             printLightBox blue " "
             printLightBox blue " CentralReport is now installed!"

--- a/install.sh
+++ b/install.sh
@@ -103,13 +103,15 @@ if [ "install" == ${ACTUAL_MODE} ]; then
             logFile "CentralReport is now installed! For more options, you can edit the config file at /etc/centralreport.cfg"
             logFile "More help at http://github.com/miniche/CentralReport. Have fun!"
 
-            printLightBox green " "
-            printLightBox green " CentralReport is now installed!"
-            printLightBox green " For more options, you can edit the config file at /etc/centralreport.cfg"
-            printLightBox green " "
-            printLightBox green " You can find more help at http://github.com/miniche/CentralReport."
-            printLightBox green " Have fun!"
-            printLightBox green " "
+            # Adds a space before the lightbox to separate previous logs with the success message.
+            logConsole " "
+            printLightBox blue " "
+            printLightBox blue " CentralReport is now installed!"
+            printLightBox blue " For more options, you can edit the config file at /etc/centralreport.cfg"
+            printLightBox blue " "
+            printLightBox blue " You can find more help at http://github.com/miniche/CentralReport."
+            printLightBox blue " Have fun!"
+            printLightBox blue " "
 
         fi
      else

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -86,9 +86,11 @@ if [ $? -eq 0 ]; then
         printLightBox red " "
 
     else
-        # No error append during uninstall. We log this, and then we display the "sad" green lightbox.
+        # Nothing wrong happened while uninstalling. We log this, and then we display the "sad" green lightbox.
         logFile "CentralReport has been deleted from your host."
 
+        # Adding a space before the lightbox to separate previous logs with the success message.
+        logConsole " "
         printLightBox blue " "
         printLightBox blue " CentralReport has been deleted from your host."
         printLightBox blue " It's sad, but you're welcome!"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -89,17 +89,17 @@ if [ $? -eq 0 ]; then
         # No error append during uninstall. We log this, and then we display the "sad" green lightbox.
         logFile "CentralReport has been deleted from your host."
 
-        printLightBox green " "
-        printLightBox green " CentralReport has been deleted from your host."
-        printLightBox green " It's sad, but you're welcome!"
-        printLightBox green " "
-        printLightBox green " PS: Thanks for your interest in CentralReport!"
-        printLightBox green " "
-        printLightBox green " One of the best ways you can help us improve CentralReport is to let us know "
-        printLightBox green " about any problems you could have found."
-        printLightBox green " You can find CR developers at http://github.com/miniche/CentralReport"
-        printLightBox green " Thanks!"
-        printLightBox green " "
+        printLightBox blue " "
+        printLightBox blue " CentralReport has been deleted from your host."
+        printLightBox blue " It's sad, but you're welcome!"
+        printLightBox blue " "
+        printLightBox blue " PS: Thanks for your interest in CentralReport!"
+        printLightBox blue " "
+        printLightBox blue " One of the best ways you can help us improve CentralReport is to let us know "
+        printLightBox blue " about any problems you could have found."
+        printLightBox blue " You can find CR developers at http://github.com/miniche/CentralReport"
+        printLightBox blue " Thanks!"
+        printLightBox blue " "
 
     fi
 else


### PR DESCRIPTION
Green color for lightbox is not a really good idea. It's look like this:
![green_lightbox](https://f.cloud.github.com/assets/1638158/153510/9e0fee8c-75fa-11e2-89fb-04cfd9b6fcf2.png)

I think it's better to use an other color. I use the blue color for the success message: 
![blue_lightbox](https://f.cloud.github.com/assets/1638158/153515/b263596e-75fa-11e2-9f7c-b72e782988b8.png)
