### PR TITLE
Fixed logging.StreamHandler for Python 2.6

### DIFF
--- a/centralreport/cr/log.py
+++ b/centralreport/cr/log.py
@@ -45,7 +45,7 @@ def get_cr_logger():
 
         if debug_mode_enabled:
             # In debug mode, we display logs on the standard output too.
-            custom_console_handler = logging.StreamHandler(stream=sys.stdout)
+            custom_console_handler = logging.StreamHandler(sys.stdout)
             custom_console_handler.setLevel(logging.DEBUG)
             custom_console_handler.setFormatter(_formatLogger())
 


### PR DESCRIPTION
Between Python 2.6 and 2.7, the StreamHandler parameters has been updated.

In 2.7: http://docs.python.org/2/library/logging.handlers.html#logging.StreamHandler
And in 2.6: http://docs.python.org/2.6/library/logging.html#logging.StreamHandler
