### PR TITLE
The log level can be personalized in the config file

### DIFF
--- a/centralreport/centralreport.py
+++ b/centralreport/centralreport.py
@@ -75,6 +75,15 @@ class CentralReport(Daemon):
         CentralReport.starting_date = datetime.datetime.now()  # Starting date
         CentralReport.configuration = Config()  # Getting config object
 
+        # The log level can be personalized in the config file
+        if Config.CR_CONFIG_ENABLE_DEBUG_MODE is False:
+            try:
+                log_level = Config.get_config_value('Debug', 'log_level')
+            except:
+                log_level = 'INFO'
+
+            log.change_log_level(log_level)
+
         # Getting current OS...
         if (Config.HOST_CURRENT == Config.HOST_MAC) or (Config.HOST_CURRENT == Config.HOST_DEBIAN) or (
                 Config.HOST_CURRENT == Config.HOST_UBUNTU):

--- a/centralreport/cr/log.py
+++ b/centralreport/cr/log.py
@@ -54,6 +54,26 @@ def get_cr_logger():
     return cr_logger
 
 
+def change_log_level(level):
+    """
+        Changes the log level. Only messages above this level will be kept.
+        Default value is "INFO"
+
+        @param level: The new level. Can be DEBUG, INFO, WARNING, ERROR or CRITICAL
+    """
+
+    if level == 'DEBUG':
+        get_cr_logger().setLevel(logging.DEBUG)
+    elif level == 'WARNING':
+        get_cr_logger().setLevel(logging.WARNING)
+    elif level == 'ERROR':
+        get_cr_logger().setLevel(logging.ERROR)
+    elif level == 'CRITICAL':
+        get_cr_logger().setLevel(logging.CRITICAL)
+    else:
+        get_cr_logger().setLevel(logging.INFO)
+
+
 def log_debug(text):
     """
         Adds a record at the DEBUG level.

--- a/centralreport/cr/tools.py
+++ b/centralreport/cr/tools.py
@@ -83,6 +83,9 @@ class Config:
             'load_warning': '75',
             'load_alert': '90'
         },
+        'Debug': {
+            'log_level': 'INFO'
+        }
     }
 
     def __init__(self):


### PR DESCRIPTION
The administrator can personalize the log level in the configuration file, in the section "Debug".

Available levels : DEBUG, INFO, WARNING, ERROR or CRITICAL.
Only messages above the selected level will be kept. The default value is remains 'info' level.

This solves the Issue https://github.com/CentralReport/CentralReport/issues/43.
