### PR TITLE
Fixed project URLs (http://github.com/CentralReport)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ We have many ideas to simplify server monitoring:
 
 
 ## Install or Uninstall CentralReport
-Please visit [Wiki installation page](https://github.com/miniche/CentralReport/wiki/Installation) to get the procedure depending on your system.
+Please visit [Wiki installation page](https://github.com/CentralReport/CentralReport/wiki/Installation) to get the procedure depending on your system.
 
 
 ## Current status
@@ -38,7 +38,7 @@ Please visit [Wiki installation page](https://github.com/miniche/CentralReport/w
 CentralReport runs on **Debian, Ubuntu and Mac OS X**.
 Right now, it's just a standalone version. It's free and very easy to use: install CentralReport and active the small web server included. You can monitor your host with a simple web browser:
 
-![Mac Screenshot](https://raw.github.com/miniche/CentralReport/develop/tools/screenshots/Capture_Mac.png)
+![Mac Screenshot](https://raw.github.com/CentralReport/CentralReport/master/tools/screenshots/Capture_Mac.png)
 
 
 __We are working on a cloud solution: you will be able to view all yours computers and servers, and set some email or push alerts.__

--- a/bash/010_uninstaller.inc.sh
+++ b/bash/010_uninstaller.inc.sh
@@ -4,7 +4,7 @@
 # CentralReport Unix/Linux "0.1.0 uninstaller"
 # Alpha version. Don't use in production environment!
 # ------------------------------------------------------------
-# https://github.com/miniche/CentralReport/
+# https://github.com/CentralReport
 # ------------------------------------------------------------
 
 # This script contains functions used to remove CentralReport 0.1.0 from the current host.

--- a/bash/functions.inc.sh
+++ b/bash/functions.inc.sh
@@ -4,7 +4,7 @@
 # CentralReport Unix/Linux - install/uninstall functions
 # Alpha version. Don't use in production environment!
 # ------------------------------------------------------------
-# https://github.com/miniche/CentralReport/
+# https://github.com/CentralReport
 # ------------------------------------------------------------
 
 # --

--- a/bash/log.inc.sh
+++ b/bash/log.inc.sh
@@ -4,7 +4,7 @@
 # CentralReport Unix/Linux - Log function
 # Alpha version. Don't use in production environment!
 # ------------------------------------------------------------
-# https://github.com/miniche/CentralReport/
+# https://github.com/CentralReport
 # ------------------------------------------------------------
 
 # Logs will be written in this file, it doesn't require administrative privileges.

--- a/bash/utils.inc.sh
+++ b/bash/utils.inc.sh
@@ -4,7 +4,7 @@
 # CentralReport Unix/Linux bash functions
 # Alpha version. Don't use in production environment!
 # ------------------------------------------------------------
-# https://github.com/miniche/CentralReport/
+# https://github.com/CentralReport
 # ------------------------------------------------------------
 
 #

--- a/bash/vars.inc.sh
+++ b/bash/vars.inc.sh
@@ -4,7 +4,7 @@
 # CentralReport Unix/Linux - bash vars
 # Alpha version. Don't use in production environment!
 # ------------------------------------------------------------
-# https://github.com/miniche/CentralReport/
+# https://github.com/CentralReport
 # ------------------------------------------------------------
 
 # This file contains all variables used by bash scripts

--- a/centralreport/centralreport.py
+++ b/centralreport/centralreport.py
@@ -5,7 +5,7 @@
     CentralReport - Main
         Entry point of the application. Can be executed with "python centralreport.py start|stop|status"
 
-    https://github.com/miniche/CentralReport/
+    https://github.com/CentralReport
 """
 
 import datetime

--- a/centralreport/config.py
+++ b/centralreport/config.py
@@ -9,7 +9,7 @@
         Important: Every console outputs must contain at most 80 characters.
         It's the default width of major consoles.
 
-    https://github.com/miniche/CentralReport/
+    https://github.com/CentralReport
 """
 
 import socket

--- a/centralreport/cr/collectors.py
+++ b/centralreport/cr/collectors.py
@@ -4,7 +4,7 @@
     CentralReport - Collectors modules
         Contains collectors for Debian/Ubuntu and OS X.
 
-    https://github.com/miniche/CentralReport/
+    https://github.com/CentralReport
 """
 
 # Summary of this module:

--- a/centralreport/cr/daemon.py
+++ b/centralreport/cr/daemon.py
@@ -4,7 +4,7 @@
     CentralReport - Daemon generic class
         Please see: http://www.jejik.com/articles/2007/02/a_simple_unix_linux_daemon_in_python/
 
-    https://github.com/miniche/CentralReport/
+    https://github.com/CentralReport
 """
 
 import atexit

--- a/centralreport/cr/entities/checks.py
+++ b/centralreport/cr/entities/checks.py
@@ -4,7 +4,7 @@
     CentralReport - Checks module
         Contains all check entities
 
-    https://github.com/miniche/CentralReport/
+    https://github.com/CentralReport
 """
 
 import datetime

--- a/centralreport/cr/entities/host.py
+++ b/centralreport/cr/entities/host.py
@@ -4,7 +4,7 @@
     CentralReport - Host module
         Contains all entities about current host (infos and disks)
 
-    https://github.com/miniche/CentralReport/
+    https://github.com/CentralReport
 """
 
 import datetime

--- a/centralreport/cr/log.py
+++ b/centralreport/cr/log.py
@@ -4,7 +4,7 @@
     CentralReport - Log module
         Contains log functions to work with native Python logging modules
 
-    https://github.com/miniche/CentralReport/
+    https://github.com/CentralReport
 """
 
 import logging

--- a/centralreport/cr/system.py
+++ b/centralreport/cr/system.py
@@ -4,7 +4,7 @@
     CentralReport - system module
         Contains functions to interact with the operating system
 
-    https://github.com/miniche/CentralReport/
+    https://github.com/CentralReport
 """
 
 import shlex

--- a/centralreport/cr/threads.py
+++ b/centralreport/cr/threads.py
@@ -4,7 +4,7 @@
     CentralReport - Threads module
         Contains threads used by CentralReport to perform periodic actions
 
-    https://github.com/miniche/CentralReport/
+    https://github.com/CentralReport
 """
 
 import datetime

--- a/centralreport/cr/tools.py
+++ b/centralreport/cr/tools.py
@@ -4,7 +4,7 @@
     CentralReport - Tools module
         Contrains Config class
 
-    https://github.com/miniche/CentralReport/
+    https://github.com/CentralReport
 """
 
 import ConfigParser

--- a/centralreport/cr/utils/date.py
+++ b/centralreport/cr/utils/date.py
@@ -4,7 +4,7 @@
     CentralReport - Date module
         Contains useful functions to working with dates
 
-    https://github.com/miniche/CentralReport/
+    https://github.com/CentralReport
 """
 
 import time

--- a/centralreport/cr/utils/text.py
+++ b/centralreport/cr/utils/text.py
@@ -4,7 +4,7 @@
     CentralReport - Text module
         Contains useful functions to working with strings
 
-    https://github.com/miniche/CentralReport/
+    https://github.com/CentralReport
 """
 
 import math

--- a/centralreport/test.py
+++ b/centralreport/test.py
@@ -6,7 +6,7 @@
         Launchs CentralReport in debug mode, without installation.
         Please verify CR is not installed on your host before launch this script.
 
-    https://github.com/miniche/CentralReport/
+    https://github.com/CentralReport
 """
 
 import sys

--- a/centralreport/web/css/style-responsive.css
+++ b/centralreport/web/css/style-responsive.css
@@ -2,7 +2,7 @@
  * CentralReport custom style - Indev version *
  * To use with Bootstrap
  *
- * Please visit https://github.com/miniche/CentralReport for more informations
+ * Please visit https://github.com/CentralReport/CentralReport for more informations
  */
 
 @media (max-width: 767px) {

--- a/centralreport/web/css/style.css
+++ b/centralreport/web/css/style.css
@@ -2,7 +2,7 @@
  * CentralReport custom style - Indev version *
  * To use with Bootstrap
  *
- * Please visit https://github.com/miniche/CentralReport for more informations
+ * Please visit https://github.com/CentralReport/CentralReport for more informations
  */
 
 /**

--- a/centralreport/web/server.py
+++ b/centralreport/web/server.py
@@ -4,7 +4,7 @@
     CentralReport - Server module
         Manages internal web server
 
-    https://github.com/miniche/CentralReport/
+    https://github.com/CentralReport
 """
 
 import datetime

--- a/centralreport/web/tpl/layout/page.layout.tpl
+++ b/centralreport/web/tpl/layout/page.layout.tpl
@@ -14,7 +14,7 @@
 
     <div class="footer">
         {% block footer_version %}CentralReport Unix/Linux{% endblock %}<br />
-        Visit <a href="http://www.github.com/miniche/CentralReport" target="_blank">Github</a> for more information
+        Visit <a href="http://www.github.com/CentralReport/CentralReport" target="_blank">Github</a> for more information
     </div>
 {% endblock %}
 

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@
 # CentralReport Unix/Linux bash installer
 # Alpha version. Don't use in production environment!
 # ------------------------------------------------------------
-# https://github.com/miniche/CentralReport/
+# https://github.com/CentralReport
 # ------------------------------------------------------------
 
 # Importing scripts...
@@ -27,7 +27,8 @@ clear
 printBox blue  "-------------------------- CentralReport installer ----------------------------| \
                 | \
                 Welcome! This script will install CentralReport on your host.| \
-                If you want more details, please visit http://github.com/miniche/CentralReport| \
+                If you want more details, | \
+                please visit http://github.com/CentralReport/CentralReport| \
                 | \
                 When installing CentralReport, we may ask for your password.| \
                 It will allow CentralReport to write files and directories such as| \
@@ -128,7 +129,7 @@ if [ "install" == ${ACTUAL_MODE} ]; then
             # Nothing wrong happened while installing. We log this, and then we display the beautiful green lightbox.
             logFile "CentralReport is now installed!"
             logFile "For more options, you can edit the config file at /etc/centralreport/centralreport.cfg"
-            logFile "More help at http://github.com/miniche/CentralReport. Have fun!"
+            logFile "More help at http://github.com/CentralReport/CentralReport. Have fun!"
 
             # Adding a space before the lightbox to separate previous logs with the success message.
             logConsole " "
@@ -136,7 +137,7 @@ if [ "install" == ${ACTUAL_MODE} ]; then
                            For more options, you can edit the config file| \
                            at /etc/centralreport/centralreport.cfg| \
                            | \
-                           You can find more help at http://github.com/miniche/CentralReport.| \
+                           You can find more help at http://github.com/CentralReport/CentralReport.| \
                            Have fun!"
 
         fi

--- a/tools/install_dev_tools.sh
+++ b/tools/install_dev_tools.sh
@@ -4,7 +4,7 @@
 # CentralReport Unix/Linux dev tools installer
 # Alpha version. Don't use in production environment!
 # ------------------------------------------------------------
-# https://github.com/miniche/CentralReport/
+# https://github.com/CentralReport
 # ------------------------------------------------------------
 
 # This script will install all thirdparties tools (CherryPy, Jinja, etc...) on the current host.
@@ -24,7 +24,8 @@ clear
 printBox blue "--------------------- CentralReport dev tools installer -----------------------| \
                | \
                Welcome! This script will install development tools on your host.| \
-               If you want more details, please visit http://github.com/miniche/CentralReport"
+               If you want more details, | \
+               please visit http://github.com/CentralReport/CentralReport"
 
 getOS
 if [ ${CURRENT_OS} != ${OS_MAC} ] && [ ${CURRENT_OS} != ${OS_DEBIAN} ]; then

--- a/tools/online_installer.sh
+++ b/tools/online_installer.sh
@@ -4,7 +4,7 @@
 # CentralReport Unix/Linux online installer
 # Alpha version. Don't use in production environment!
 # ------------------------------------------------------------
-# https://github.com/miniche/CentralReport/
+# https://github.com/CentralReport
 # ------------------------------------------------------------
 
 # This script will download latest CentralReport version, and begin installation.

--- a/tools/online_uninstaller.sh
+++ b/tools/online_uninstaller.sh
@@ -4,7 +4,7 @@
 # CentralReport Unix/Linux online uninstaller
 # Alpha version. Don't use in production environment!
 # ------------------------------------------------------------
-# https://github.com/miniche/CentralReport/
+# https://github.com/CentralReport
 # ------------------------------------------------------------
 
 # This script will download latest CentralReport version, and begin uninstall on current host.

--- a/tools/packager.sh
+++ b/tools/packager.sh
@@ -4,7 +4,7 @@
 # CentralReport Unix/Linux packager
 # Alpha version. Don't use in production environment!
 # ------------------------------------------------------------
-# https://github.com/miniche/CentralReport/
+# https://github.com/CentralReport
 # ------------------------------------------------------------
 
 # This script package CentralReport in one archive (.tar.gz)

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -4,7 +4,7 @@
 # CentralReport Unix/Linux uninstaller
 # Alpha version. Don't use in production environment!
 # ------------------------------------------------------------
-# https://github.com/miniche/CentralReport/
+# https://github.com/CentralReport
 # ------------------------------------------------------------
 
 # Importing some scripts
@@ -24,7 +24,8 @@ clear
 printBox blue "------------------------- CentralReport uninstaller ---------------------------| \
                | \
                Welcome! This script will uninstall CentralReport on your host.| \
-               If you want more details, please visit http://github.com/miniche/CentralReport"
+               If you want more details, | \
+               please visit http://github.com/CentralReport/CentralReport"
 
 # Getting current OS to check if uninstall will work for this host
 getOS
@@ -112,7 +113,7 @@ if [ $? -eq 0 ]; then
                        Thanks for your interest in CentralReport!| \
                        One of the best ways you can help us improve CentralReport is to let us know| \
                        about any problems you could have found.| \
-                       You can find CR developers at http://github.com/miniche/CentralReport| \
+                       You can find CR developers at http://github.com/CentralReport| \
                        Thanks!"
 
     fi

--- a/utils/bin/centralreport
+++ b/utils/bin/centralreport
@@ -4,7 +4,7 @@
 # CentralReport Unix/Linux - Binary script
 # Alpha version. Don't use in production environment!
 # ------------------------------------------------------------
-# https://github.com/miniche/CentralReport/
+# https://github.com/CentralReport
 # ------------------------------------------------------------
 
 # This script allows to manage the CentralReport daemon.


### PR DESCRIPTION
The repository has moved from https://github.com/miniche to https://github.com/CentralReport.

URLs previously defined in the project have to be updated.

---

This solve the issue https://github.com/CentralReport/CentralReport/issues/55
