### PR TITLE
Fixed imports in the dev tools script

### DIFF
--- a/tools/install_dev_tools.sh
+++ b/tools/install_dev_tools.sh
@@ -12,6 +12,7 @@
 
 source ../bash/vars.inc.sh
 source ../bash/log.inc.sh
+source ../bash/utils.inc.sh
 source ../bash/functions.inc.sh
 
 #=============================================================================


### PR DESCRIPTION
The import of the "utils.inc.sh" was massing in the dev tools.
It works now, tested on OS X.
