### PR TITLE
Removed support of Python 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@
 
 language: python
 python:
-  - "2.5"
   - "2.6"
   - "2.7"
 

--- a/NEWS
+++ b/NEWS
@@ -27,6 +27,8 @@ Version Alpha 0.3.0 (Not released yet)
 
     - Fix #73: Removed old config.py script
 
+    - Fix #79: Removed support for Python 2.5 and older
+
 
 --------------------------------------------------------------
 Version Alpha 0.2.0 (April 24th, 2013)

--- a/bash/utils.inc.sh
+++ b/bash/utils.inc.sh
@@ -55,17 +55,15 @@ function check_python {
 
     # Checking Python availability
     python -V &> /dev/null
-    if [ $? -ne 0 ]; then
+    if [ "$?" -ne 0 ]; then
         return 1
     fi
 
-    python -c 'import sys; print (sys.version_info >= (2, 6) and "1" or "0")' &> /dev/null
-    if [ $? -eq 0 ]; then
+    if [ $(python -c 'import sys; print (sys.version_info < (2, 6) and "1" or "0")') -eq 1 ]; then
         return 2
     fi
 
-    python -c 'import sys; print (sys.version_info >= (3, 0) and "1" or "0")' &> /dev/null
-    if [ $? -eq 0 ]; then
+    if [ $(python -c 'import sys; print (sys.version_info >= (3, 0) and "1" or "0")') -eq 1 ]; then
         return 3
     fi
 

--- a/bash/utils.inc.sh
+++ b/bash/utils.inc.sh
@@ -42,20 +42,31 @@ function getOS(){
 }
 
 #
-# Displays the python version (if python is available)
+# Checks whether python is available
 #
 # PARAMETERS: None
 # RETURN:
-#   0 = Python is not available on this host
-#   1 = Python is available
+#   0 = Python is available
+#   1 = Python is not available on this host
+#   2 = Python version is too old
+#   3 = Python version is 3.0 or newer
 #
-function getPythonIsInstalled {
+function check_python {
 
-    echo " "
+    # Checking Python availability
     python -V &> /dev/null
-
     if [ $? -ne 0 ]; then
         return 1
+    fi
+
+    python -c 'import sys; print (sys.version_info >= (2, 6) and "1" or "0")' &> /dev/null
+    if [ $? -eq 0 ]; then
+        return 2
+    fi
+
+    python -c 'import sys; print (sys.version_info >= (3, 0) and "1" or "0")' &> /dev/null
+    if [ $? -eq 0 ]; then
+        return 3
     fi
 
     return 0

--- a/centralreport/centralreport.py
+++ b/centralreport/centralreport.py
@@ -180,6 +180,14 @@ class CentralReport(Daemon):
 #
 
 if '__main__' == __name__:
+
+    if sys.version_info < (2, 6):
+        print "CentralReport works only with Python 2.6 or newer."
+        sys.exit(1)
+    elif sys.version_info >= (3, 0):
+        print "CentralReport doesn't work with Python 3.0 or newer."
+        sys.exit(1)
+
     daemon = CentralReport(Config.CR_PID_FILE)
 
     if 2 == len(sys.argv):

--- a/centralreport/cr/collectors.py
+++ b/centralreport/cr/collectors.py
@@ -263,10 +263,7 @@ class DebianCollector(_Collector):
         kernel_v = platform.release()
 
         # Getting OS Name and OS version
-        if sys.version_info[:2] < (2, 6):  # Python < 2.6
-            from platform import dist
-        else:
-            from platform import linux_distribution as dist
+        from platform import linux_distribution as dist
 
             # Getting OS Name and OS version
         try:

--- a/install.sh
+++ b/install.sh
@@ -44,13 +44,14 @@ fi
 
 # Python is mandatory for CentralReport
 check_python
-if [ $? -eq 1 ]; then
+RETURN_PYTHON_CHECK="$?"
+if [ "${RETURN_PYTHON_CHECK}" -eq 1 ]; then
     printBox red "Error! Python must be installed on your host to execute CentralReport."
     exit 1
-elif [ $? -eq 2 ]; then
+elif [ "${RETURN_PYTHON_CHECK}" -eq 2 ]; then
     printBox red "Error! CentralReport is only designed to work with Python 2.6 or newer."
     exit 1
-elif [ $? -eq 3 ]; then
+elif [ "${RETURN_PYTHON_CHECK}" -eq 3 ]; then
     printBox red "Error! CentralReport doesn't work with Python 3.0 or newer!"
     exit 1
 fi

--- a/install.sh
+++ b/install.sh
@@ -43,10 +43,15 @@ if [ ${CURRENT_OS} != ${OS_MAC} ] && [ ${CURRENT_OS} != ${OS_DEBIAN} ]; then
 fi
 
 # Python is mandatory for CentralReport
-getPythonIsInstalled
-if [ $? -ne 0 ]; then
-    printBox red " Error! Python must be installed on your host to execute CentralReport."
-
+check_python
+if [ $? -eq 1 ]; then
+    printBox red "Error! Python must be installed on your host to execute CentralReport."
+    exit 1
+elif [ $? -eq 2 ]; then
+    printBox red "Error! CentralReport is only designed to work with Python 2.6 or newer."
+    exit 1
+elif [ $? -eq 3 ]; then
+    printBox red "Error! CentralReport doesn't work with Python 3.0 or newer!"
     exit 1
 fi
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -39,13 +39,6 @@ if [ ${CURRENT_OS} != ${OS_MAC} ] && [ ${CURRENT_OS} != ${OS_DEBIAN} ]; then
     exit 1
 fi
 
-getPythonIsInstalled
-if [ $? -ne 0 ]; then
-    printBox red "Error! Python must be installed on your host to remove CentralReport."
-
-    exit 1
-fi
-
 # On debian, the current user must have administrative privileges.
 if [ "${CURRENT_OS}" == "${OS_DEBIAN}" ]; then
     if [[ $EUID -ne 0 ]]; then


### PR DESCRIPTION
All supported distributions (Ubuntu, Debian and CentOS soon) are shipped with Python 2.6 or Python 2.7.
Now, many libraries doesn't support Python 2.5 (such as "Routes" in our case), and we are using some modules (like the "json" one) only available since the version 2.6.

This pull request removes the support of Python 2.5 and adds two new checks: one in the installer and one in centralreport.py, before starting the daemon.

Please notice that CR is not fully compatible with Python 3. Many changes are needed, and they will be done in a next release.
