### PR TITLE
Fixed "sudo -n" and "sudo -v" for OS X Mavericks

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -48,6 +48,7 @@ Version Alpha 0.3.0 (Not released yet)
 
     - Fix #81: Removed flot.js library and 'dashboard_mac' template
 
+    - Fix #84: Fixed "sudo -n" and "sudo -v" for OS X Mavericks
 
 --------------------------------------------------------------
 Version Alpha 0.2.0 (April 24th, 2013)

--- a/install.sh
+++ b/install.sh
@@ -101,17 +101,13 @@ else
             logInfo "Processing... CentralReport will be installed on this Mac."
 
             # On Mac OS, the user must have access to administrative commands.
-            # Checking whether the "sudo" session is still alive...
-            sudo -n echo "hey" > /dev/null 2>&1
-            if [ "$?" -ne 0 ]; then
-
-                echo -e "\n\nPlease use your administrator password to install CentralReport on this Mac."
-                sudo -v
-                if [ $? -ne 0 ]; then
-                    logError "Unable to use root privileges!"
-                    bit_error=1
-                fi
+            echo -e "\n"
+            sudo -v -p "Please enter your administrator password to install CentralReport on this Mac: "
+            if [ $? -ne 0 ]; then
+                logError "Unable to use root privileges!"
+                bit_error=1
             fi
+
         elif [ ${CURRENT_OS} == ${OS_DEBIAN} ] && [ ${CURRENT_OS} == ${OS_CENTOS} ]
         then
             logInfo "Processing... CentralReport will be installed on this Linux."

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -76,17 +76,13 @@ else
             logInfo "Processing... CentralReport will be removed from this Mac."
 
             # On Mac OS, the user must have access to administrative commands.
-            # Checking whether the "sudo" session is still alive...
-            sudo -n echo "hey" > /dev/null 2>&1
-            if [ "$?" -ne 0 ]; then
-
-                echo -e "\n\nPlease use your administrator password to uninstall CentralReport from this Mac."
-                sudo -v
-                if [ $? -ne 0 ]; then
-                    logError "Unable to use root privileges!"
-                    bit_error=1
-                fi
+            echo -e "\n"
+            sudo -v -p "Please enter your administrator password to uninstall CentralReport on this Mac: "
+            if [ $? -ne 0 ]; then
+                logError "Unable to use root privileges!"
+                bit_error=1
             fi
+
         elif [ ${CURRENT_OS} == ${OS_DEBIAN} ] && [ ${CURRENT_OS} == ${OS_CENTOS} ]; then
             logInfo "Processing... CentralReport will be removed from this Linux."
         fi


### PR DESCRIPTION
CentralReport must have administrative privileges to install or uninstall itself.
In the bash scripts (install.sh and uninstall.sh), we are testing whether the sudo session still alive. On OS X 10.9 Mavericks, the command "sudo -n" returns 0, even if the sudo session is not alive.

Replaced by "sudo -v -p", with a custom message.
If the sudo session is alive, the message is not displayed.

![capture decran 2013-10-30 a 23 21 02](https://f.cloud.github.com/assets/1638158/1441803/9a38dbc4-41b1-11e3-9ca0-a96e0b751e2d.png)
