### PR TITLE
Fixed the installer when is called from the online script [0.3.0]

### DIFF
--- a/bash/functions.inc.sh
+++ b/bash/functions.inc.sh
@@ -76,7 +76,7 @@ function start_wizard(){
 
     if [ ! "${ARG_S}" ]; then
         printTitle "Starting the CLI wizard..."
-        execute_privileged_command python ${CR_LIB_MANAGER} wizard
+        execute_privileged_command python ${CR_LIB_MANAGER} wizard < /dev/tty
     fi
 }
 


### PR DESCRIPTION
When the user uses the online installer (with "curl http://static.centralreport.net/installer | bash"), the CLI Manager (in "Wizard mode") could not start.
We force the use of  /dev/tty in input for the urwid library.
