### PR TITLE
New host module and fixed memory collector for OS X 10.9 Mavericks

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,12 @@
 # More at: https://github.com/CentralReport/CentralReport/
 # ------------------------------------------------------------
 
+--------------------------------------------------------------
+Version Alpha 0.4.0 (Not released yet)
+
+    - Improvement #87: New host module and fixed memory collector for OS X 10.9 Mavericks
+        * The host data are now obtained in a specific module (host.py)
+        * The memory collector works well on OS X 10.9, with the memory compression
 
 --------------------------------------------------------------
 Version Alpha 0.3.0 (November 4th, 2013)

--- a/centralreport/centralreport.py
+++ b/centralreport/centralreport.py
@@ -19,6 +19,7 @@ import os
 CR_CURRENT_DIR = os.path.abspath(os.path.dirname(__file__))
 sys.path.insert(0, os.path.join(CR_CURRENT_DIR, 'libs/urwid-1.1.1.zip'))
 
+from cr import host
 from cr import log
 from cr import threads
 from cr.utils import text
@@ -80,6 +81,9 @@ class CentralReport(Daemon):
         CentralReport.starting_date = datetime.datetime.now()  # Starting date
         CentralReport.configuration = Config()  # Getting config object
 
+        # Getting data about the current host...
+        host.get_current_host()
+
         # The log level can be personalized in the config file
         if Config.CR_CONFIG_ENABLE_DEBUG_MODE is False:
             try:
@@ -89,16 +93,15 @@ class CentralReport(Daemon):
 
             log.change_log_level(log_level)
 
-        # Launching the check thread...
-        # Getting current OS...
-        if Config.HOST_CURRENT != Config.HOST_OTHER:
-            log.log_info('%s detected. Starting ThreadChecks...' % Config.HOST_CURRENT)
+        # Starting the check thread...
+        if host.get_current_host().os != host.OS_UNKNOWN:
+            log.log_info('%s detected. Starting ThreadChecks...' % host.get_current_host().os)
             CentralReport.checks_thread = threads.Checks()  # Launching checks thread
         else:
             is_error = True
             log.log_critical('Sorry, but your OS is not supported yet...')
 
-        # Launching the internal webserver...
+        # Starting the internal webserver...
         if not is_error and text.convert_text_to_bool(Config.get_config_value('Webserver', 'enable')):
             local_web_port = int(Config.get_config_value('Webserver', 'port'))
 

--- a/centralreport/centralreport.py
+++ b/centralreport/centralreport.py
@@ -78,10 +78,9 @@ class CentralReport(Daemon):
         signal.signal(signal.SIGTERM, self.signal_handler)
         signal.signal(signal.SIGINT, self.signal_handler)
 
-        CentralReport.starting_date = datetime.datetime.now()  # Starting date
-        CentralReport.configuration = Config()  # Getting config object
+        CentralReport.starting_date = datetime.datetime.now()
+        CentralReport.configuration = Config()
 
-        # Getting data about the current host...
         host.get_current_host()
 
         # The log level can be personalized in the config file

--- a/centralreport/cr/collectors.py
+++ b/centralreport/cr/collectors.py
@@ -29,9 +29,6 @@ from cr.tools import Config
 
 
 class _Collector:
-    def get_infos(self):
-        raise NameError('Method not implemented yet')
-
     def get_cpu(self):
         raise NameError('Method not implemented yet')
 
@@ -55,53 +52,6 @@ class MacCollector(_Collector):
 
     PAGEBYTES_TO_BYTES = 4096.
     BLOCKBYTES_TO_BYTES = 512.
-
-    def get_infos(self):
-        """
-            Gets information about this Mac.
-        """
-
-        hostname = text.remove_specials_characters(system.execute_command('hostname -s'))
-
-        architecture = platform.machine()
-
-        kernel = platform.system()
-        kernel_v = platform.release()
-
-        os_name = system.execute_command('sw_vers -productName')
-        os_version = system.execute_command('sw_vers -productVersion')
-
-        model = system.execute_command('sysctl -n hw.model')
-
-        # Number of CPU/CPU cores
-        ncpu = 1
-
-        try:
-            ncpu = multiprocessing.cpu_count()
-        except (ImportError, NotImplementedError):
-            try:
-                ncpu = system.execute_command('sysctl -n hw.ncpu')
-            except IOError:
-                pass
-
-        cpu_model = system.execute_command('sysctl -n machdep.cpu.brand_string')
-
-        # Using new HostEntity
-        host_entity = host.Infos()
-
-        host_entity.uuid = Config.get_config_value('General', 'uuid')
-        host_entity.os = Config.HOST_CURRENT
-        host_entity.hostname = hostname
-        host_entity.architecture = architecture
-        host_entity.model = model
-        host_entity.kernel_name = kernel
-        host_entity.kernel_version = kernel_v
-        host_entity.os_name = os_name
-        host_entity.os_version = os_version
-        host_entity.cpu_model = cpu_model
-        host_entity.cpu_count = ncpu
-
-        return host_entity
 
     def get_cpu(self):
         """
@@ -249,66 +199,6 @@ class DebianCollector(_Collector):
     """
         Collector executing Debian/Ubuntu commands and getting useful values.
     """
-
-    def get_infos(self):
-        """
-            Gets information about this host.
-        """
-
-        hostname = socket.gethostname()
-
-        architecture = platform.machine()
-
-        kernel = platform.system()
-        kernel_v = platform.release()
-
-        # Getting OS Name and OS version
-        from platform import linux_distribution as dist
-
-            # Getting OS Name and OS version
-        try:
-            os_name = dist()[0]
-            os_version = dist()[1]
-        except:
-            os_name = 'Linux'
-            os_version = ''
-
-        # TODO Find a way to find the computer model
-        #model = system.execute_command('sysctl -n hw.model')
-
-        # Number of CPU/CPU cores
-        ncpu = 1
-
-        try:
-            ncpu = multiprocessing.cpu_count()
-        except (ImportError, NotImplementedError):
-            try:
-                ncpu = open('/proc/cpuinfo').read().count('processor\t:')
-            except IOError:
-                pass
-
-        cpu_infos = system.execute_command('cat /proc/cpuinfo | grep "model name"')
-        if "model name" in cpu_infos:
-            cpu_model = re.sub(".*model name.*:", "", cpu_infos, 1)
-        else:
-            cpu_model = 'CPU model unknown'
-
-        # Using new HostEntity
-        host_entity = host.Infos()
-
-        host_entity.uuid = Config.get_config_value('General', 'uuid')
-        host_entity.os = Config.HOST_CURRENT
-        host_entity.hostname = hostname
-        host_entity.architecture = architecture
-        #host_entity.model = model
-        host_entity.kernel_name = kernel
-        host_entity.kernel_version = kernel_v
-        host_entity.os_name = os_name
-        host_entity.os_version = os_version
-        host_entity.cpu_model = cpu_model
-        host_entity.cpu_count = ncpu
-
-        return host_entity
 
     def get_cpu(self):
         """

--- a/centralreport/cr/entities/host.py
+++ b/centralreport/cr/entities/host.py
@@ -11,13 +11,17 @@ import datetime
 import json
 
 
-class Infos:
+class Host:
     """
-        Entity containing datas about actual host.
+        Entity containing details about actual host.
     """
 
     def __init__(self):
         self.architecture = ''
+
+        self.family = ''
+        self.variant = ''
+        self.os = ''
 
         # TODO: move it in CPU check.
 
@@ -39,7 +43,6 @@ class Infos:
 
         self.language = 'Python'  # CentralReport app language
         self.model = ''  # Only for Mac OS
-        self.os = ''
         self.uuid = ''
 
     def json_serialize(self):

--- a/centralreport/cr/host.py
+++ b/centralreport/cr/host.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+
+"""
+    CentralReport - Collectors modules
+        Contains collectors for Debian/Ubuntu and OS X.
+
+    https://github.com/CentralReport
+"""
+
+import platform
+import multiprocessing
+import re
+import socket
+
+import cr.entities.host as crEntityHost
+import cr.utils.text as text
+import system
+
+#: @type _current_host: cr.entities.host.Host
+_current_host = None
+
+# OS family names
+FAMILY_UNIX = 'Unix'
+FAMILY_LINUX = 'Linux'
+FAMILY_UNKNOWN = 'Unknown'
+
+# Family variant
+VARIANT_MAC = 'Mac'
+VARIANT_DEBIAN = 'Debian'
+VARIANT_REDHAT = 'RedHat'
+VARIANT_UNKNOWN = 'Unknown'
+
+# Specific OS names
+OS_MAC = 'OS X'
+OS_DEBIAN = 'Debian'
+OS_UBUNTU = 'Ubuntu'
+OS_CENTOS = 'CentOS'
+OS_UNKNOWN = 'Unsupported'
+
+
+def get_current_host():
+    """
+        Gets the Host object, for the current OS
+
+        @return: cr.entities.host.Host
+    """
+
+    global _current_host
+
+    if _current_host is not None:
+        return _current_host
+
+    _current_host = crEntityHost.Host()
+
+    _current_host.family = FAMILY_UNKNOWN
+    _current_host.variant = VARIANT_UNKNOWN
+    _current_host.os = OS_UNKNOWN
+
+    kernel = platform.system()
+
+    if kernel.startswith('Darwin'):
+        _current_host.family = FAMILY_UNIX
+        _current_host.variant = VARIANT_MAC
+        _current_host.os = OS_MAC
+
+    elif kernel.startswith('Linux'):
+        _current_host.family = FAMILY_LINUX
+
+        if platform.linux_distribution()[0] == "Ubuntu":
+            _current_host.variant = VARIANT_DEBIAN
+            _current_host.os = OS_UBUNTU
+
+        elif platform.linux_distribution()[0] == "debian":
+            _current_host.variant = VARIANT_DEBIAN
+            _current_host.os = OS_DEBIAN
+
+        elif platform.linux_distribution()[0] == "CentOS":
+            _current_host.variant = VARIANT_REDHAT
+            _current_host.os = OS_CENTOS
+
+        else:
+            return _current_host
+
+    else:
+        return _current_host
+
+    # Common getters between all OS families
+    _current_host.architecture = platform.machine()
+    _current_host.kernel_name = kernel
+    _current_host.kernel_version = platform.release()
+
+    # Specific getters
+    if _current_host.os == OS_MAC:
+        _current_host.hostname = text.remove_specials_characters(system.execute_command('hostname -s'))
+        _current_host.os_name = system.execute_command('sw_vers -productName')
+        _current_host.os_version = system.execute_command('sw_vers -productVersion')
+        _current_host.model = system.execute_command('sysctl -n hw.model')
+
+        _current_host.cpu_model = system.execute_command('sysctl -n machdep.cpu.brand_string')
+        _current_host.cpu_count = 1
+        try:
+            _current_host.cpu_count = multiprocessing.cpu_count()
+        except (ImportError, NotImplementedError):
+            try:
+                _current_host.cpu_count = system.execute_command('sysctl -n hw.ncpu')
+            except IOError:
+                pass
+
+    if _current_host.family == FAMILY_LINUX:
+        _current_host.hostname = socket.gethostname()
+        _current_host.os_name = platform.linux_distribution()[0]
+        _current_host.os_version = platform.linux_distribution()[1]
+
+        _current_host.cpu_count = 1
+        try:
+            _current_host = multiprocessing.cpu_count()
+        except (ImportError, NotImplementedError):
+            try:
+                _current_host = open('/proc/cpuinfo').read().count('processor\t:')
+            except IOError:
+                pass
+
+        cpu_info = system.execute_command('cat /proc/cpuinfo | grep "model name"')
+        if "model name" in cpu_info:
+            _current_host.cpu_model = re.sub(".*model name.*:", "", cpu_info, 1)
+        else:
+            _current_host.cpu_model = 'CPU model unknown'

--- a/centralreport/cr/host.py
+++ b/centralreport/cr/host.py
@@ -93,7 +93,7 @@ def get_current_host():
     if _current_host.os == OS_MAC:
         _current_host.hostname = text.remove_specials_characters(system.execute_command('hostname -s'))
         _current_host.os_name = system.execute_command('sw_vers -productName')
-        _current_host.os_version = system.execute_command('sw_vers -productVersion')
+        _current_host.os_version = text.remove_specials_characters(system.execute_command('sw_vers -productVersion'))
         _current_host.model = system.execute_command('sysctl -n hw.model')
 
         _current_host.cpu_model = system.execute_command('sysctl -n machdep.cpu.brand_string')
@@ -113,10 +113,10 @@ def get_current_host():
 
         _current_host.cpu_count = 1
         try:
-            _current_host = multiprocessing.cpu_count()
+            _current_host.cpu_count = multiprocessing.cpu_count()
         except (ImportError, NotImplementedError):
             try:
-                _current_host = open('/proc/cpuinfo').read().count('processor\t:')
+                _current_host.cpu_count = open('/proc/cpuinfo').read().count('processor\t:')
             except IOError:
                 pass
 

--- a/centralreport/cr/threads.py
+++ b/centralreport/cr/threads.py
@@ -13,6 +13,7 @@ import time
 
 from cr import collectors
 from cr import log
+import cr.host
 from cr.utils.text import convert_text_to_bool
 from cr.tools import Config
 
@@ -22,10 +23,7 @@ class Checks(threading.Thread):
         Thread performing periodically checks.
     """
 
-    hostEntity = None  # Get host informations
-
     # Last checks (with new entities classes)
-
     last_check_cpu = None
     last_check_date = None
     last_check_disk = None
@@ -39,13 +37,13 @@ class Checks(threading.Thread):
         threading.Thread.__init__(self)
         log.log_debug('ThreadChecks is starting...')  # Standard output
 
-        # What is the current os?
 
-        if Config.HOST_CURRENT == Config.HOST_MAC:
+        if cr.host.get_current_host().os == cr.host.OS_MAC:
             self.MyCollector = collectors.MacCollector()
-        elif (Config.HOST_CURRENT == Config.HOST_DEBIAN) or (Config.HOST_CURRENT == Config.HOST_UBUNTU) or \
-                (Config.HOST_CURRENT == Config.HOST_CENTOS):
+        elif cr.host.get_current_host().family == cr.host.FAMILY_LINUX:
             self.MyCollector = collectors.DebianCollector()
+        else:
+            raise TypeError
 
         # Perform a check every xx ticks (1 tick = 1 second)
 
@@ -62,10 +60,6 @@ class Checks(threading.Thread):
         """
             Executes checks.
         """
-
-        # Getting informations about the current host
-
-        Checks.hostEntity = self.MyCollector.get_infos()
 
         while Checks.performChecks:
             if self.tickPerformCheck <= self.tickCount:
@@ -86,23 +80,17 @@ class Checks(threading.Thread):
                     log.log_debug('Doing a load average check...')
                     Checks.last_check_loadAverage = self.MyCollector.get_loadaverage()
 
-                # Checking disks informations
+                # Checking disks information
                 if convert_text_to_bool(Config.get_config_value('Checks', 'enable_disks_check')):
                     log.log_debug('Doing a disk check...')
                     Checks.last_check_disk = self.MyCollector.get_disks()
 
-                # Updating last check date...
-
                 Checks.last_check_date = datetime.datetime.now()  # Update the last check date
-
-                # Wait 60 seconds before next checks...
 
                 log.log_debug('All checks are done')
                 log.log_debug('Next checks in %s seconds...' % self.tickPerformCheck)
 
                 self.tickCount = 0
-
-            # new tick
 
             self.tickCount += 1
             time.sleep(1)

--- a/centralreport/cr/tools.py
+++ b/centralreport/cr/tools.py
@@ -9,9 +9,7 @@
 
 import ConfigParser
 import os
-import platform
 import uuid
-import sys
 
 from cr import log
 
@@ -35,20 +33,6 @@ class Config:
 
     # Default interval between two checks (use this if not available in the config file)
     CR_CONFIG_DEFAULT_CHECKS_INTERVAL = int(60)
-
-    # Current host
-    HOST_CURRENT = ''
-
-    # Some hosts...
-    HOST_MAC = 'Mac OS X'
-    HOST_LINUX = 'Linux'
-    HOST_DEBIAN = 'Debian'
-    HOST_UBUNTU = 'Ubuntu'
-    HOST_REDHAT = 'RedHat'
-    HOST_FEDORA = 'Fedora'
-    HOST_ARCH = 'Arch Linux'
-    HOST_CENTOS = 'CentOS'
-    HOST_OTHER = 'Unsupported'
 
     # CentralReport pid file
     if CR_CONFIG_ENABLE_DEBUG_MODE:
@@ -96,14 +80,6 @@ class Config:
         """
             Constructor
         """
-
-        Config.determine_current_host()
-
-        if Config.HOST_CURRENT == Config.HOST_MAC:
-            log.log_debug('Mac config')
-        else:
-            log.log_debug('Linux config')
-
         # Managing config file
         if os.path.isfile(Config.CR_CONFIG_FULL_PATH):
             log.log_debug('Configuration file: Found. Reading it.')
@@ -207,52 +183,3 @@ class Config:
             Config._CR_CONFIG_VALUES[section][variable] = value
         except:
             raise NameError('Section or Variable not found! (%s/%s)' % (section, variable))
-
-    @staticmethod
-    def determine_current_host():
-        """
-            Detecting current OS...
-        """
-
-        kernel = platform.system()
-
-        if kernel.startswith('Darwin'):
-            Config.HOST_CURRENT = Config.HOST_MAC
-        elif kernel.startswith('Linux'):
-            Config.HOST_CURRENT = Config.HOST_LINUX
-
-            # On va essayer d'affiner en fonction des distributions
-
-            # Utilisation de la liste de Novell pour reconnaitre des distrib Linux
-            # http://www.novell.com/coolsolutions/feature/11251.html - Deprecated here
-
-            # Getting OS Name and OS version
-            if sys.version_info[:2] < (2, 6):  # Python < 2.6
-                from platform import dist
-            else:
-                from platform import linux_distribution as dist
-
-            # TODO More distros will be added as soon as we need them
-            # List of major linux distrib : http://distrowatch.com/dwres.php?resource=popularity
-
-            if dist()[0] == "Ubuntu":
-                # Ubuntu
-                Config.HOST_CURRENT = Config.HOST_UBUNTU
-            elif dist()[0] == "debian":
-                # Debian
-                Config.HOST_CURRENT = Config.HOST_DEBIAN
-            #elif dist()[0] == "Fedora":
-                # Fedora
-            #    Config.HOST_CURRENT = Config.HOST_FEDORA
-            #elif dist()[0] == "redhat" or dist()[0] == 'Red Hat Enterprise Linux Server':
-                # RedHat
-            #    Config.HOST_CURRENT = Config.HOST_REDHAT
-            #elif os.path.isfile('/etc/arch-release'):
-                # ArchLinux
-            #    Config.HOST_CURRENT = Config.HOST_ARCH
-            elif dist()[0] == "CentOS":
-                # CentOS
-                Config.HOST_CURRENT = Config.HOST_CENTOS
-            else:
-                # No match, default
-                Config.HOST_CURRENT = Config.HOST_OTHER

--- a/centralreport/web/server.py
+++ b/centralreport/web/server.py
@@ -14,6 +14,8 @@ import threading
 
 # By che: Temporary section. Will be improved soon.
 # Testing importing zip libraries...
+import cr.host
+
 sys.path.insert(0, os.path.abspath(__file__ + '/../../libs/jinja2-2.6.zip'))
 sys.path.insert(0, os.path.abspath(__file__ + '/../../libs/cherrypy-3.2.2.zip'))
 
@@ -232,7 +234,7 @@ class Api:
 
                     tmpl_vars['load_last_one'] = Checks.last_check_loadAverage.last1m
                     tmpl_vars['load_percent'] = (float(Checks.last_check_loadAverage.last1m) * 100) / int(
-                        Checks.hostEntity.cpu_count)
+                        cr.host.get_current_host().cpu_count)
 
                     if int(tmpl_vars['load_percent']) >= int(Config.get_config_value('Alerts', 'load_alert')):
                         tmpl_vars['load_state'] = Api.STATE_ALERT
@@ -290,17 +292,17 @@ class Pages:
         tmpl_vars = dict()
 
         # Host information
-        tmpl_vars['hostname'] = Checks.hostEntity.hostname
-        tmpl_vars['os_name'] = Checks.hostEntity.os_name
-        tmpl_vars['os_version'] = Checks.hostEntity.os_version
+        tmpl_vars['hostname'] = cr.host.get_current_host().hostname
+        tmpl_vars['os_name'] = cr.host.get_current_host().os_name
+        tmpl_vars['os_version'] = cr.host.get_current_host().os_version
 
-        if Config.HOST_CURRENT == Config.HOST_MAC:
+        if cr.host.get_current_host().os == cr.host.OS_MAC:
             tmpl_vars['host_os'] = 'MAC'
-        elif Config.HOST_CURRENT == Config.HOST_UBUNTU:
+        elif cr.host.get_current_host().os == cr.host.OS_UBUNTU:
             tmpl_vars['host_os'] = 'UBUNTU'
-        elif Config.HOST_CURRENT == Config.HOST_DEBIAN:
+        elif cr.host.get_current_host().os == cr.host.OS_DEBIAN:
             tmpl_vars['host_os'] = 'DEBIAN'
-        elif Config.HOST_CURRENT == Config.HOST_CENTOS:
+        elif cr.host.get_current_host().os == cr.host.OS_CENTOS:
             tmpl_vars['host_os'] = 'CENTOS'
 
         tmpl_vars['CR_version'] = Config.CR_VERSION
@@ -316,7 +318,7 @@ class Pages:
             tmpl_vars['cpu_percent'] = 100 - int(Checks.last_check_cpu.idle)
             tmpl_vars['cpu_user'] = Checks.last_check_cpu.user
             tmpl_vars['cpu_system'] = Checks.last_check_cpu.system
-            tmpl_vars['cpu_count'] = Checks.hostEntity.cpu_count
+            tmpl_vars['cpu_count'] = cr.host.get_current_host().cpu_count
 
             if int(tmpl_vars['cpu_percent']) >= int(Config.get_config_value('Alerts', 'cpu_alert')):
                 tmpl_vars['cpu_alert'] = True
@@ -380,7 +382,7 @@ class Pages:
         if Checks.last_check_loadAverage is not None:
             tmpl_vars['loadaverage'] = Checks.last_check_loadAverage.last1m
             tmpl_vars['loadaverage_percent'] = (float(Checks.last_check_loadAverage.last1m) * 100) / int(
-                Checks.hostEntity.cpu_count)
+                cr.host.get_current_host().cpu_count)
 
             if int(tmpl_vars['loadaverage_percent']) >= int(Config.get_config_value('Alerts', 'load_alert')):
                 tmpl_vars['load_alert'] = True


### PR DESCRIPTION
Apple had integrated the WKdm algorithm to compress data in the RAM, in OS X 10.9 Mavericks.
Unused memory can be compressed to free more memory, without swapping.

I have tested this behavior on my MacBook Pro with 8 GB of RAM. Mac OS X can give 12 GB of memory to the system and to the applications, before starting swap on the hard drive/SSD! Just incredible.
During this process, the CPU occupation is higher.

You can read more about it on:
- http://www.apple.com/osx/advanced-technologies/
- http://terpconnect.umd.edu/~barua/matt-compress-tr.pdf

So, to do it, Apple had added new page types for the memory (see #85).
CentralReport can now analyse them and displays right data about memory.

I have added the "cr.host" module. It contains all code to determine the current host and to get information about it. It was previously in the "collector" module, which is destined to died in a next release.
