### PR TITLE
Added timezone management in the Javascript part

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,8 @@ Version Alpha 0.5.0 (Not released yet)
     - Fix #93: Fixed uptime displayed on the web server
         * Seconds are now refreshed in uptime data
 
+    - Fix #94: Added timezone management in the Javascript part
+
 --------------------------------------------------------------
 Version Alpha 0.4.0 (November 22nd, 2013)
 

--- a/centralreport/cr/utils/date.py
+++ b/centralreport/cr/utils/date.py
@@ -10,8 +10,6 @@
 import datetime
 import sys
 
-from cr import log
-
 
 def datetime_to_timestamp(datetime_to_convert):
     """

--- a/centralreport/tests/utils/date.py
+++ b/centralreport/tests/utils/date.py
@@ -19,8 +19,8 @@ class CrTimestampTest(unittest.TestCase):
     """
 
     def test_datetime_to_timestamp(self):
-        date_to_convert = datetime.datetime(2012, 10, 10, 10, 10, 10)
-        self.assertEqual(cr_date.datetime_to_timestamp(date_to_convert), 1349863810L)
+        date_to_convert = datetime.datetime(2010, 1, 1, 1, 1, 1)
+        self.assertEqual(cr_date.datetime_to_timestamp(date_to_convert), 1262307661L)
 
     def test_wrong_timestamp(self):
         date_to_convert = datetime.datetime(2012, 10, 10, 10, 10, 10)

--- a/centralreport/web/js/cr.ajax.js
+++ b/centralreport/web/js/cr.ajax.js
@@ -8,6 +8,7 @@
  */
 
 var actualClientTimestamp = 0;  // Client timestamp
+var actualClientTimezoneOffset = 0; // Client timezone offset, in seconds
 var lastTimestamp = 0;  // Last check timestamp (server side)
 var nextCheckAt = 0;  // Next check will be occur at this timestamp (client side)
 var checksInterval = 60; // Interval between two checks
@@ -25,6 +26,7 @@ var updateNextCheckCounter = function () {
 
     if (0 !== nextCheckAt){
         actualClientTimestamp = Math.round(new Date().getTime() / 1000);
+
         nextCheckIn = parseInt(nextCheckAt - actualClientTimestamp, 10) + 3;
 
         ajaxEnabledElement = $('#ajax_enabled');
@@ -78,8 +80,8 @@ var verifyIsNewCheckIsAvailable = function () {
 
                     ajaxEnabledElement.text('Getting last check...');
 
-                    lastTimestamp = parseInt(data['last_timestamp'], 10);
-                    server_timestamp = parseInt(data['current_timestamp'], 10);
+                    lastTimestamp = parseInt(data['last_timestamp'], 10) + actualClientTimezoneOffset;
+                    server_timestamp = parseInt(data['current_timestamp'], 10) + actualClientTimezoneOffset;
 
                     // Differences between computer clock and client clock
                     actualClientTimestamp = Math.round(new Date().getTime() / 1000);
@@ -332,6 +334,9 @@ var createProgressBar = function (element, value) {
  */
 $(function () {
     $('#ajax_enabled').text('Ajax refresh enabled...');  // Enable Ajax auto refresh
+
+    actualClientTimezoneOffset = new Date().getTimezoneOffset() * 60;
+
     updateNextCheckCounter();
     verifyIsNewCheckIsAvailable();
 });


### PR DESCRIPTION
The timezone can be different between the host and the client.

With #77, the datetime to timestamp function now returns an UTC time instead of a local time.
The javascript functions handle an UTC time too to calculate time intervals.
