### PR TITLE
Fixed installer/uninstaller whitelist for NEWS.md

### DIFF
--- a/tools/packager/installer_whitelist.txt
+++ b/tools/packager/installer_whitelist.txt
@@ -14,5 +14,5 @@ utils/
 AUTHORS
 install.sh
 LICENSE
-NEWS
+NEWS.md
 README.md

--- a/tools/packager/uninstaller_whitelist.txt
+++ b/tools/packager/uninstaller_whitelist.txt
@@ -13,5 +13,5 @@ utils/
 AUTHORS
 uninstall.sh
 LICENSE
-NEWS
+NEWS.md
 README.md


### PR DESCRIPTION
"News" file was renamed in #95 ("NEWS" to "NEWS.md").
