### PR TITLE
Fixed for..in loop in the Linux collector

### DIFF
--- a/centralreport/cr/collectors.py
+++ b/centralreport/cr/collectors.py
@@ -337,7 +337,7 @@ class DebianCollector(_Collector):
                     disk_name = disks_by_uuid[disk_id]
                     disk_uuid = disk_id
                 else:
-                    for key, value in disks_by_uuid:
+                    for key, value in disks_by_uuid.iteritems():
                         if value == disk_id:
                             disk_name = value
                             disk_uuid = key


### PR DESCRIPTION
Stupid error... In Python, we must specify on which item we want to iterate in a directory (key, values or key/values)
http://stackoverflow.com/questions/3294889/iterating-over-dictionaries-for-loops-in-python/3294899#3294899
